### PR TITLE
specs: add Requesty to the model catalog

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -552,6 +552,7 @@ ccproxy:
       api.openai.com: openai
       generativelanguage.googleapis.com: google
       openrouter.ai: openrouter
+      router.requesty.ai: requesty
     mitmproxy:
       ssl_insecure: true
       web_host: 127.0.0.1

--- a/src/ccproxy/specs/model_catalog.py
+++ b/src/ccproxy/specs/model_catalog.py
@@ -52,6 +52,11 @@ STATIC_MODEL_CATALOG: dict[str, list[str]] = {
     "deepseek": [
         "deepseek-v4",
     ],
+    "requesty": [
+        "openai/gpt-4o-mini",
+        "anthropic/claude-sonnet-4-5",
+        "google/gemini-2.5-flash",
+    ],
     "perplexity": _perplexity_model_ids(),
 }
 """Provider → model IDs floor list. Updated alongside provider releases."""
@@ -60,6 +65,7 @@ STATIC_MODEL_CATALOG: dict[str, list[str]] = {
 _PROVIDER_ENDPOINTS: dict[str, str] = {
     "anthropic": "https://api.anthropic.com/v1/models",
     "openrouter": "https://openrouter.ai/api/v1/models",
+    "requesty": "https://router.requesty.ai/v1/models",
 }
 """Provider → upstream ``/v1/models`` URL for live merge. gemini is omitted
 because it requires GCP project context that ccproxy doesn't have at

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -43,6 +43,14 @@ def test_static_floor_contains_known_gemini_models() -> None:
     assert "gemini-2.5-flash" in ids
 
 
+def test_static_floor_contains_known_requesty_models() -> None:
+    """The floor includes known Requesty (OpenAI-compatible gateway) model IDs."""
+    catalog = build_catalog()
+    ids = {entry["id"] for entry in catalog["data"]}
+    assert "openai/gpt-4o-mini" in ids
+    assert "anthropic/claude-sonnet-4-5" in ids
+
+
 def test_owned_by_matches_provider_keys() -> None:
     """Each entry's ``owned_by`` is one of the provider keys in STATIC_MODEL_CATALOG."""
     catalog = build_catalog()
@@ -86,6 +94,33 @@ def test_refresh_merges_live_anthropic_models() -> None:
     # No duplicates of the floor entry — the live anthropic block runs first
     # so the floor copy is skipped via the (owned_by, id) dedup set.
     assert ids.count("claude-opus-4-7") == 1
+
+
+def test_refresh_merges_live_requesty_models() -> None:
+    """``refresh=True`` unions live Requesty models with the static floor (deduped)."""
+    set_config_instance(CCProxyConfig())
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "router.requesty.ai" in str(request.url):
+            return httpx.Response(
+                200,
+                json={
+                    "object": "list",
+                    "data": [
+                        # one new model not in the floor
+                        {"id": "deepseek/deepseek-chat", "object": "model", "created": 1700000000},
+                        # one duplicate of a floor entry
+                        {"id": "openai/gpt-4o-mini", "object": "model"},
+                    ],
+                },
+            )
+        return httpx.Response(404)
+
+    catalog = build_catalog(refresh=True, transport=httpx.MockTransport(handler))
+    ids = [entry["id"] for entry in catalog["data"]]
+    assert "deepseek/deepseek-chat" in ids
+    # The duplicate floor entry is not double-counted (deduped by (owned_by, id)).
+    assert ids.count("openai/gpt-4o-mini") == 1
 
 
 def test_refresh_provider_failure_falls_back_to_floor() -> None:


### PR DESCRIPTION
## What

Adds [Requesty](https://requesty.ai) to the model catalog, mirroring how OpenRouter is wired. Requesty is an OpenAI-compatible gateway that exposes a standard `/v1/models` endpoint, so it slots into both the static floor and the live-merge path.

- `src/ccproxy/specs/model_catalog.py`:
  - `requesty` floor list in `STATIC_MODEL_CATALOG`
  - `"requesty": "https://router.requesty.ai/v1/models"` in `_PROVIDER_ENDPOINTS` (the live-merge fetch uses `Authorization: Bearer`, which Requesty accepts)
- `tests/test_model_catalog.py`: a floor test and a live-merge test for `requesty` (mirroring the anthropic ones)
- `docs/configuration.md`: `router.requesty.ai -> requesty` in the `provider_map` example

Floor model IDs are limited to slugs I verified actually route on Requesty.

## Tested

- `uv run pytest tests/test_model_catalog.py` — 15 passed (incl. 2 new)
- `uv run pytest tests/ -k "catalog or models or config or spec"` — 260 passed
- `uv run ruff check` and `uv run mypy` on the touched module — clean
- Confirmed `GET https://router.requesty.ai/v1/models` returns an OpenAI-shaped `{object: list, data: [...]}` payload.

Note: I couldn't get a clean run of the *entire* suite locally — an unrelated test elsewhere hangs at ~59% on my machine (looks like an e2e/namespace test needing network/WireGuard), well outside this change. The catalog area and its neighbors are fully green. Happy to adjust if CI surfaces anything.

## Disclosure

I work at Requesty. This mirrors the existing OpenRouter catalog entry. Happy to adjust naming/placement or close if it's not a fit.